### PR TITLE
fix probes

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -3,7 +3,7 @@ name: homarr
 description: A Helm chart to deploy homarr for Kubernetes
 home: https://homarr-labs.github.io/charts/charts/homarr/
 type: application
-version: 8.2.3
+version: 8.2.4
 # renovate datasource=docker depName=ghcr.io/homarr-labs/homarr
 appVersion: "v1.43.3"
 icon: https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg
@@ -21,8 +21,8 @@ annotations:
     fingerprint: 36F9A886ABA6AA4C1588B942E7EC1AA0EFD54840
     url: https://homarr-labs.github.io/charts/pgp_keys.asc
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update ghcr.io/homarr-labs/homarr docker tag to v1.43.3
+    - kind: fixed
+      description: fix probes
   artifacthub.io/links: |-
     - name: App Source
       url: https://github.com/homarr-labs/homarr

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg" align="right" width="92" alt="homarr logo">
 
-![Version: 8.2.3](https://img.shields.io/badge/Version-8.2.3-informational?style=flat)
+![Version: 8.2.4](https://img.shields.io/badge/Version-8.2.4-informational?style=flat)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat)
 ![AppVersion: v1.43.3](https://img.shields.io/badge/AppVersion-v1.43.3-informational?style=flat)
 
@@ -435,8 +435,12 @@ All available values are listed on the [artifacthub](https://artifacthub.io/pack
 | ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/"}]}]` | Ingress hosts configuration |
 | ingress.ingressClassName | string | `""` | Ingress class name |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
+| livenessProbe.httpGet.failureThreshold | int | `3` |  |
+| livenessProbe.httpGet.initialDelaySeconds | int | `10` | Initial delay before readiness probe is executed. increase this value if the pod is slow to fully start.  |
 | livenessProbe.httpGet.path | string | `"/api/health/live"` | This is the liveness check endpoint used by Kubernetes to determine if the application is still running. |
+| livenessProbe.httpGet.periodSeconds | int | `10` |  |
 | livenessProbe.httpGet.port | int | `7575` | The port on which the liveness check will be performed. This must be the same as the container port exposed by the application. |
+| livenessProbe.httpGet.timeoutSeconds | int | `1` |  |
 | nameOverride | string | `""` | Overrides chart's name |
 | nodeSelector | object | `{}` | Node selectors for pod scheduling |
 | persistence.homarrDatabase.accessMode | string | `"ReadWriteOnce"` | homarr-database access mode |
@@ -457,8 +461,12 @@ All available values are listed on the [artifacthub](https://artifacthub.io/pack
 | podSecurityContext | object | `{}` | Pod security context |
 | rbac | object | `{"enabled":false}` | Enable RBAC resources for Kubernetes integration Creates Role, ClusterRole, and associated bindings for Homarr's Kubernetes features |
 | rbac.enabled | bool | `false` | Enable to create RBAC resources and activate Kubernetes integration |
+| readinessProbe.httpGet.failureThreshold | int | `3` |  |
+| readinessProbe.httpGet.initialDelaySeconds | int | `10` | Initial delay before readiness probe is executed. increase this value if the pod is slow to fully start.  |
 | readinessProbe.httpGet.path | string | `"/api/health/ready"` | This is the readiness check endpoint used by Kubernetes to determine if the application is ready to handle traffic. |
+| readinessProbe.httpGet.periodSeconds | int | `10` |  |
 | readinessProbe.httpGet.port | int | `7575` | The port on which the readiness check will be performed. This must match the container's exposed port. |
+| readinessProbe.httpGet.timeoutSeconds | int | `1` |  |
 | replicaCount | int | `1` | Number of replicas |
 | resources | object | `{}` | Resource configuration |
 | securityContext | object | `{}` | Security context |

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -435,12 +435,12 @@ All available values are listed on the [artifacthub](https://artifacthub.io/pack
 | ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/"}]}]` | Ingress hosts configuration |
 | ingress.ingressClassName | string | `""` | Ingress class name |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
-| livenessProbe.httpGet.failureThreshold | int | `3` |  |
-| livenessProbe.httpGet.initialDelaySeconds | int | `10` | Initial delay before readiness probe is executed. increase this value if the pod is slow to fully start.  |
+| livenessProbe.failureThreshold | int | `3` | Failure threshold for liveness probe - number of consecutive failures before pod is restarted |
 | livenessProbe.httpGet.path | string | `"/api/health/live"` | This is the liveness check endpoint used by Kubernetes to determine if the application is still running. |
-| livenessProbe.httpGet.periodSeconds | int | `10` |  |
 | livenessProbe.httpGet.port | int | `7575` | The port on which the liveness check will be performed. This must be the same as the container port exposed by the application. |
-| livenessProbe.httpGet.timeoutSeconds | int | `1` |  |
+| livenessProbe.initialDelaySeconds | int | `10` | Initial delay in seconds before the liveness probe starts |
+| livenessProbe.periodSeconds | int | `10` | Period in seconds between liveness probe checks |
+| livenessProbe.timeoutSeconds | int | `1` | Timeout in seconds for each liveness probe check |
 | nameOverride | string | `""` | Overrides chart's name |
 | nodeSelector | object | `{}` | Node selectors for pod scheduling |
 | persistence.homarrDatabase.accessMode | string | `"ReadWriteOnce"` | homarr-database access mode |
@@ -461,12 +461,12 @@ All available values are listed on the [artifacthub](https://artifacthub.io/pack
 | podSecurityContext | object | `{}` | Pod security context |
 | rbac | object | `{"enabled":false}` | Enable RBAC resources for Kubernetes integration Creates Role, ClusterRole, and associated bindings for Homarr's Kubernetes features |
 | rbac.enabled | bool | `false` | Enable to create RBAC resources and activate Kubernetes integration |
-| readinessProbe.httpGet.failureThreshold | int | `3` |  |
-| readinessProbe.httpGet.initialDelaySeconds | int | `10` | Initial delay before readiness probe is executed. increase this value if the pod is slow to fully start.  |
+| readinessProbe.failureThreshold | int | `3` | Failure threshold for readiness probe - number of consecutive failures before pod is considered unready |
 | readinessProbe.httpGet.path | string | `"/api/health/ready"` | This is the readiness check endpoint used by Kubernetes to determine if the application is ready to handle traffic. |
-| readinessProbe.httpGet.periodSeconds | int | `10` |  |
 | readinessProbe.httpGet.port | int | `7575` | The port on which the readiness check will be performed. This must match the container's exposed port. |
-| readinessProbe.httpGet.timeoutSeconds | int | `1` |  |
+| readinessProbe.initialDelaySeconds | int | `10` | Initial delay in seconds before the readiness probe starts. increase this value if the pod is slow to fully start. |
+| readinessProbe.periodSeconds | int | `10` | Period in seconds between readiness probe checks |
+| readinessProbe.timeoutSeconds | int | `1` | Timeout in seconds for each readiness probe check |
 | replicaCount | int | `1` | Number of replicas |
 | resources | object | `{}` | Resource configuration |
 | securityContext | object | `{}` | Security context |

--- a/charts/homarr/templates/homarr-dc.yaml
+++ b/charts/homarr/templates/homarr-dc.yaml
@@ -49,21 +49,13 @@ spec:
               protocol: {{ $portSpec.protocol }}
               {{- end }}
             {{- end }}
-          {{- if .Values.livenessProbe }}
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 12 }}
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.readinessProbe }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 12 }}
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
            {{- if .Values.rbac.enabled }}

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -160,13 +160,13 @@ service:
   ipFamilies: [ ]
 
 livenessProbe:
-  # Failure threshold for liveness probe - number of consecutive failures before pod is restarted
+  # -- Failure threshold for liveness probe - number of consecutive failures before pod is restarted
   failureThreshold: 3
-  # Initial delay in seconds before the liveness probe starts
+  # -- Initial delay in seconds before the liveness probe starts
   initialDelaySeconds: 10
-  # Timeout in seconds for each liveness probe check
+  # -- Timeout in seconds for each liveness probe check
   timeoutSeconds: 1
-  # Period in seconds between liveness probe checks
+  # -- Period in seconds between liveness probe checks
   periodSeconds: 10
   httpGet:
     # -- This is the liveness check endpoint used by Kubernetes to determine if the application is still running.
@@ -176,13 +176,13 @@ livenessProbe:
     # -- Initial delay before readiness probe is executed. increase this value if the pod is slow to fully start. 
 
 readinessProbe:
-  # Failure threshold for readiness probe - number of consecutive failures before pod is considered unready
+  # -- Failure threshold for readiness probe - number of consecutive failures before pod is considered unready
   failureThreshold: 3
-  # Initial delay in seconds before the readiness probe starts. increase this value if the pod is slow to fully start.
+  # -- Initial delay in seconds before the readiness probe starts. increase this value if the pod is slow to fully start.
   initialDelaySeconds: 10
-  # Timeout in seconds for each readiness probe check
+  # -- Timeout in seconds for each readiness probe check
   timeoutSeconds: 1
-  # Period in seconds between readiness probe checks
+  # -- Period in seconds between readiness probe checks
   periodSeconds: 10
   httpGet:
     # -- This is the readiness check endpoint used by Kubernetes to determine if the application is ready to handle traffic.

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -160,28 +160,35 @@ service:
   ipFamilies: [ ]
 
 livenessProbe:
+  # Failure threshold for liveness probe - number of consecutive failures before pod is restarted
+  failureThreshold: 3
+  # Initial delay in seconds before the liveness probe starts
+  initialDelaySeconds: 10
+  # Timeout in seconds for each liveness probe check
+  timeoutSeconds: 1
+  # Period in seconds between liveness probe checks
+  periodSeconds: 10
   httpGet:
     # -- This is the liveness check endpoint used by Kubernetes to determine if the application is still running.
     path: /api/health/live
     # -- The port on which the liveness check will be performed. This must be the same as the container port exposed by the application.
     port: 7575
     # -- Initial delay before readiness probe is executed. increase this value if the pod is slow to fully start. 
-    initialDelaySeconds: 10
-    timeoutSeconds: 1
-    periodSeconds: 10
-    failureThreshold: 3
 
 readinessProbe:
+  # Failure threshold for readiness probe - number of consecutive failures before pod is considered unready
+  failureThreshold: 3
+  # Initial delay in seconds before the readiness probe starts. increase this value if the pod is slow to fully start.
+  initialDelaySeconds: 10
+  # Timeout in seconds for each readiness probe check
+  timeoutSeconds: 1
+  # Period in seconds between readiness probe checks
+  periodSeconds: 10
   httpGet:
     # -- This is the readiness check endpoint used by Kubernetes to determine if the application is ready to handle traffic.
     path: /api/health/ready
     # -- The port on which the readiness check will be performed. This must match the container's exposed port.
     port: 7575
-    # -- Initial delay before readiness probe is executed. increase this value if the pod is slow to fully start. 
-    initialDelaySeconds: 10
-    timeoutSeconds: 1
-    periodSeconds: 10
-    failureThreshold: 3
 
 # -- containerPorts defines the ports to open on the container. It is a map where each entry specifies:
 #    - `port`     (int)    (required): The port number to expose inside the container.

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -165,6 +165,11 @@ livenessProbe:
     path: /api/health/live
     # -- The port on which the liveness check will be performed. This must be the same as the container port exposed by the application.
     port: 7575
+    # -- Initial delay before readiness probe is executed. increase this value if the pod is slow to fully start. 
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 10
+    failureThreshold: 3
 
 readinessProbe:
   httpGet:
@@ -172,6 +177,11 @@ readinessProbe:
     path: /api/health/ready
     # -- The port on which the readiness check will be performed. This must match the container's exposed port.
     port: 7575
+    # -- Initial delay before readiness probe is executed. increase this value if the pod is slow to fully start. 
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 10
+    failureThreshold: 3
 
 # -- containerPorts defines the ports to open on the container. It is a map where each entry specifies:
 #    - `port`     (int)    (required): The port number to expose inside the container.


### PR DESCRIPTION
this is to make the livenessProbe and the readinessProbe get templated directly from the values.
this fixes issue [#184](https://github.com/homarr-labs/charts/issues/184)