### PR TITLE
fix: migrate renovate config from regexManagers to customManagers syntax

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,9 +8,10 @@
     "{{datasource}}",
     "{{updateType}}"
   ],
-  "regexManagers": [
+  "customManagers": [
     {
-      "fileMatch": ["\\.yaml$"],
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)Chart\\.yaml$/"],
       "matchStrings": [
         "# ?renovate datasource=(?<datasource>.+?) depName=(?<depName>.+)\\n.+: [\"']?(?<currentValue>.+?)[\"']?\\n"
       ]


### PR DESCRIPTION
Migrates the old `regexManagers` config key to the current `customManagers` with `customType: 'regex'` and `managerFilePatterns` (renamed from `fileMatch`).

Also scopes `managerFilePatterns` to `Chart.yaml` only (was matching all `.yaml` files) to avoid conflicts with Renovate's built-in `helmv3` manager.

**Evidence:**
- Renovate docs show `customManagers` as the current config key, with `regexManagers` listed under `previouslyKnownAs`: https://docs.renovatebot.com/configuration-options/#custommanagers
- The regex manager docs use `customManagers` with `customType: 'regex'` and `managerFilePatterns`, with a specific example for `Chart.yaml` `appVersion`: https://docs.renovatebot.com/modules/manager/regex/
- Renovate PR #32784 (Jan 2025) formalized `customManagers` as the standard: https://github.com/renovatebot/renovate/pull/32784

The old `regexManagers` / `fileMatch` syntax was silently dropped in a recent Renovate update, causing the custom manager to stop extracting the Homarr Docker tag entirely.

Fixes Renovate no longer detecting Homarr Docker image versions.