### PR TITLE
fix: use app token for homarr repo checkout

### DIFF
--- a/.github/workflows/sync-docs.yaml
+++ b/.github/workflows/sync-docs.yaml
@@ -32,7 +32,7 @@ jobs:
           repository: homarr-labs/homarr
           path: target-repo
           token: ${{ steps.obtainToken.outputs.token }}
-          ref: dev
+          ref: main
 
       - name: Sync Documentation
         run: |
@@ -53,7 +53,7 @@ jobs:
         with:
           token: ${{ steps.obtainToken.outputs.token }}
           branch: docs/update-helm-docs
-          base: dev
+          base: main
           title: Update Helm chart documentation
           delete-branch: true
           path: target-repo

--- a/.github/workflows/sync-docs.yaml
+++ b/.github/workflows/sync-docs.yaml
@@ -17,12 +17,21 @@ jobs:
             charts/homarr/README.md
           sparse-checkout-cone-mode: false
 
+      - name: Obtain token
+        id: obtainToken
+        uses: tibdex/github-app-token@v2
+        with:
+          private_key: ${{ secrets.HOMARR_DOCS_SYNC_APP_PRIVATE_KEY }}
+          app_id: ${{ vars.HOMARR_DOCS_SYNC_APP_ID }}
+          installation_retrieval_mode: repository
+          installation_retrieval_payload: homarr-labs/homarr
+
       - name: Checkout Homarr docs
         uses: actions/checkout@v6
         with:
           repository: homarr-labs/homarr
           path: target-repo
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.obtainToken.outputs.token }}
           ref: dev
 
       - name: Sync Documentation
@@ -37,15 +46,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "docs(helm): Update Helm chart documentation" || echo "No changes to commit"
-
-      - name: Obtain token
-        id: obtainToken
-        uses: tibdex/github-app-token@v2
-        with:
-          private_key: ${{ secrets.HOMARR_DOCS_SYNC_APP_PRIVATE_KEY }}
-          app_id: ${{ vars.HOMARR_DOCS_SYNC_APP_ID }}
-          installation_retrieval_mode: repository
-          installation_retrieval_payload: homarr-labs/homarr
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
The previous PR (#253) used `secrets.GITHUB_TOKEN` to clone `homarr-labs/homarr`, but the default `GITHUB_TOKEN` is scoped to the current repo (`homarr-labs/charts`) and can't authenticate against other repos.

This moves the `Obtain token` step before the checkout and uses the GitHub App token for cloning instead.