### PR TITLE
chore(deps): update ghcr.io/homarr-labs/homarr docker tag to v1.68.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -5,7 +5,7 @@ home: https://homarr-labs.github.io/charts/charts/homarr/
 type: application
 version: 8.19.0
 # renovate datasource=docker depName=ghcr.io/homarr-labs/homarr
-appVersion: "v1.60.0"
+appVersion: "v1.68.0"
 icon: https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg
 kubeVersion: ">=1.24.0-0"
 keywords:

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -3,7 +3,7 @@ name: homarr
 description: A Helm chart to deploy homarr for Kubernetes
 home: https://homarr-labs.github.io/charts/charts/homarr/
 type: application
-version: 8.19.0
+version: 8.20.0
 # renovate datasource=docker depName=ghcr.io/homarr-labs/homarr
 appVersion: "v1.68.0"
 icon: https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg
@@ -22,7 +22,7 @@ annotations:
     url: https://homarr-labs.github.io/charts/pgp_keys.asc
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update ghcr.io/homarr-labs/homarr docker tag to v1.60.0
+      description: Update ghcr.io/homarr-labs/homarr docker tag to v1.68.0
   artifacthub.io/links: |-
     - name: App Source
       url: https://github.com/homarr-labs/homarr

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -2,9 +2,9 @@
 
 <img src="https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg" align="right" width="92" alt="homarr logo">
 
-![Version: 8.19.0](https://img.shields.io/badge/Version-8.19.0-informational?style=flat)
+![Version: 8.20.0](https://img.shields.io/badge/Version-8.20.0-informational?style=flat)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat)
-![AppVersion: v1.60.0](https://img.shields.io/badge/AppVersion-v1.60.0-informational?style=flat)
+![AppVersion: v1.68.0](https://img.shields.io/badge/AppVersion-v1.68.0-informational?style=flat)
 
 A Helm chart to deploy homarr for Kubernetes
 
@@ -428,7 +428,7 @@ All available values are listed on the [artifacthub](https://artifacthub.io/pack
 | httproute.rules[0].matches[0].path.value | string | `"/"` | Path value to match |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ghcr.io/homarr-labs/homarr"` | Image repository |
-| image.tag | string | `"v1.60.0"` | Overrides the image tag whose default is the chart appVersion |
+| image.tag | string | `"v1.68.0"` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` | Secrets for Docker registry |
 | ingress.annotations | object | `{}` | Ingress annotations |
 | ingress.enabled | bool | `false` | Enable ingress |

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion
-  tag: "v1.60.0"
+  tag: "v1.68.0"
 
 env:
   # -- Your local time zone

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -26,6 +26,8 @@ env:
   ENABLE_DNS_CACHING: "false"
   # -- Enabled authentication methods. Multiple providers can be enabled with by separating them with , (ex. AUTH_PROVIDERS=credentials,oidc, it is highly recommended to just enable one provider).
   AUTH_PROVIDERS: "credentials"
+  # -- Prefix used for all authentication cookies. Change if you run another Auth.js/NextAuth app on the same hostname to avoid cookie name collisions. Only letters, numbers, hyphens and underscores.
+  AUTH_COOKIE_PREFIX: "homarr"
   # -- URL to redirect to after clicking logging out.
   AUTH_LOGOUT_REDIRECT_URL:
   # -- Time for the session to time out. Can be set as pure number, which will automatically be used in seconds, or followed by s, m, h or d for seconds, minutes, hours or days. (ex: "30m")


### PR DESCRIPTION
This PR updates the Docker image tag to v1.68.0.