### PR TITLE
feat: add AUTH_COOKIE_PREFIX env var to chart

### DIFF
--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -26,6 +26,8 @@ env:
   ENABLE_DNS_CACHING: "false"
   # -- Enabled authentication methods. Multiple providers can be enabled with by separating them with , (ex. AUTH_PROVIDERS=credentials,oidc, it is highly recommended to just enable one provider).
   AUTH_PROVIDERS: "credentials"
+  # -- Prefix used for all authentication cookies. Change if you run another Auth.js/NextAuth app on the same hostname to avoid cookie name collisions. Only letters, numbers, hyphens and underscores.
+  AUTH_COOKIE_PREFIX: "homarr"
   # -- URL to redirect to after clicking logging out.
   AUTH_LOGOUT_REDIRECT_URL:
   # -- Time for the session to time out. Can be set as pure number, which will automatically be used in seconds, or followed by s, m, h or d for seconds, minutes, hours or days. (ex: "30m")


### PR DESCRIPTION
Prevents the sync-docs workflow from removing `AUTH_COOKIE_PREFIX` documentation from the homarr docs site whenever the chart README is synced.