### PR TITLE
chore(deps): update ghcr.io/homarr-labs/homarr docker tag to v1.68.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -5,7 +5,7 @@ home: https://homarr-labs.github.io/charts/charts/homarr/
 type: application
 version: 8.19.0
 # renovate datasource=docker depName=ghcr.io/homarr-labs/homarr
-appVersion: "v1.60.0"
+appVersion: "v1.68.0"
 icon: https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg
 kubeVersion: ">=1.24.0-0"
 keywords:

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -3,7 +3,7 @@ name: homarr
 description: A Helm chart to deploy homarr for Kubernetes
 home: https://homarr-labs.github.io/charts/charts/homarr/
 type: application
-version: 8.19.0
+version: 8.20.0
 # renovate datasource=docker depName=ghcr.io/homarr-labs/homarr
 appVersion: "v1.68.0"
 icon: https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg
@@ -22,7 +22,7 @@ annotations:
     url: https://homarr-labs.github.io/charts/pgp_keys.asc
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update ghcr.io/homarr-labs/homarr docker tag to v1.60.0
+      description: Update ghcr.io/homarr-labs/homarr docker tag to v1.68.0
   artifacthub.io/links: |-
     - name: App Source
       url: https://github.com/homarr-labs/homarr

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -2,9 +2,9 @@
 
 <img src="https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg" align="right" width="92" alt="homarr logo">
 
-![Version: 8.19.0](https://img.shields.io/badge/Version-8.19.0-informational?style=flat)
+![Version: 8.20.0](https://img.shields.io/badge/Version-8.20.0-informational?style=flat)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat)
-![AppVersion: v1.60.0](https://img.shields.io/badge/AppVersion-v1.60.0-informational?style=flat)
+![AppVersion: v1.68.0](https://img.shields.io/badge/AppVersion-v1.68.0-informational?style=flat)
 
 A Helm chart to deploy homarr for Kubernetes
 
@@ -383,6 +383,7 @@ All available values are listed on the [artifacthub](https://artifacthub.io/pack
 | containerPorts | object | `{"http":{"port":7575,"protocol":"TCP"}}` | containerPorts defines the ports to open on the container. It is a map where each entry specifies:    - `port`     (int)    (required): The port number to expose inside the container.    - `protocol` (string) (required): The network protocol (TCP or UDP) used for the port.    - `disabled` (bool)              : Optional flag to disable this port (defaults to false). Can be overridden via Helm values.  By default, this configuration exposes TCP port 7575 with the name `http`. |
 | database.migrationEnabled | bool | `true` | Database migration configuration. DB_MIGRATIONS_DISABLED Set to `true` to disable database migrations. Migrations are enabled by default (`false`). |
 | database.type | string | `"sqlite"` | Database type: sqlite, mysql or postgresql |
+| env.AUTH_COOKIE_PREFIX | string | `"homarr"` | Prefix used for all authentication cookies. Change if you run another Auth.js/NextAuth app on the same hostname to avoid cookie name collisions. Only letters, numbers, hyphens and underscores. |
 | env.AUTH_LDAP_BASE | string | `nil` | Base dn of your LDAP server |
 | env.AUTH_LDAP_BIND_DN | string | `nil` | User used for finding users and groups |
 | env.AUTH_LDAP_GROUP_CLASS | string | `"groupOfUniqueNames"` | Class used for querying groups |


### PR DESCRIPTION
🤖 This PR updates the Docker image tag to v1.68.0.