### PR TITLE
fix: Change HTTPRoute default port from 8080 to 7575

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -3,7 +3,7 @@ name: homarr
 description: A Helm chart to deploy homarr for Kubernetes
 home: https://homarr-labs.github.io/charts/charts/homarr/
 type: application
-version: 8.22.0
+version: 8.22.1
 # renovate datasource=docker depName=ghcr.io/homarr-labs/homarr
 appVersion: "v1.70.0"
 icon: https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -21,8 +21,8 @@ annotations:
     fingerprint: 36F9A886ABA6AA4C1588B942E7EC1AA0EFD54840
     url: https://homarr-labs.github.io/charts/pgp_keys.asc
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update ghcr.io/homarr-labs/homarr docker tag to v1.70.0
+    - kind: fixed
+      description: Changed default HTTPRoute backendRefs port to 7575
   artifacthub.io/links: |-
     - name: App Source
       url: https://github.com/homarr-labs/homarr

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -259,7 +259,7 @@ httproute:
             value: /
       backendRefs:
         - name: homarr
-          port: 8080
+          port: 7575
 ````
 </details>
 
@@ -419,11 +419,11 @@ All available values are listed on the [artifacthub](https://artifacthub.io/pack
 | envSecrets.dbEncryption.key | string | `"db-encryption-key"` | Secret key for SECRET_ENCRYPTION_KEY can be generated with `openssl rand -hex 32` |
 | fullnameOverride | string | `""` | Overrides chart's fullname |
 | hostAliases | list | `[]` | Add static entries to /etc/hosts in the Pod. This is useful in the following cases: - You are running in a dual-stack cluster (IPv4 + IPv6) and want to force usage of IPv4 for specific hostnames - Your application is having DNS resolution issues or IPv6 preference issues - You need to override or simulate DNS entries without changing global DNS - You are running in an air-gapped or isolated environment without external DNS Example: hostAliases:   - ip: "192.168.1.10"     hostnames:       - "example.com"       - "example.internal" |
-| httproute | object | `{"enabled":false,"hostnames":["chart-example.local"],"parentRefs":[{"name":"my-gateway","namespace":"default"}],"rules":[{"backendRefs":[{"name":"homarr","port":8080}],"filters":[],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` | Gateway API HTTPRoute configuration |
+| httproute | object | `{"enabled":false,"hostnames":["chart-example.local"],"parentRefs":[{"name":"my-gateway","namespace":"default"}],"rules":[{"backendRefs":[{"name":"homarr","port":7575}],"filters":[],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` | Gateway API HTTPRoute configuration |
 | httproute.enabled | bool | `false` | Enable HTTPRoute |
 | httproute.hostnames | list | `["chart-example.local"]` | Hostnames this route matches (similar to ingress.hosts.host) |
 | httproute.parentRefs | list | `[{"name":"my-gateway","namespace":"default"}]` | References to the parent Gateway(s) this route attaches to. Each item must include at least a `name`, and optionally a `namespace`. |
-| httproute.rules | list | `[{"backendRefs":[{"name":"homarr","port":8080}],"filters":[],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | List of routing rules. Each rule can include: - matches: path/header/query matching - filters: optional transformations (redirects, header modifications, etc.) - backendRefs: one or more Kubernetes Services to forward traffic to |
+| httproute.rules | list | `[{"backendRefs":[{"name":"homarr","port":7575}],"filters":[],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | List of routing rules. Each rule can include: - matches: path/header/query matching - filters: optional transformations (redirects, header modifications, etc.) - backendRefs: one or more Kubernetes Services to forward traffic to |
 | httproute.rules[0].filters | list | `[]` | Optional filters for this rule (default: empty) |
 | httproute.rules[0].matches[0].path.type | string | `"PathPrefix"` | Path match type. One of: Exact, PathPrefix, RegularExpression |
 | httproute.rules[0].matches[0].path.value | string | `"/"` | Path value to match |

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/homarr-labs/charts/refs/heads/main/charts/homarr/icon.svg" align="right" width="92" alt="homarr logo">
 
-![Version: 8.22.0](https://img.shields.io/badge/Version-8.22.0-informational?style=flat)
+![Version: 8.22.1](https://img.shields.io/badge/Version-8.22.1-informational?style=flat)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat)
 ![AppVersion: v1.70.0](https://img.shields.io/badge/AppVersion-v1.70.0-informational?style=flat)
 

--- a/charts/homarr/README_CONFIG.md.gotmpl
+++ b/charts/homarr/README_CONFIG.md.gotmpl
@@ -199,7 +199,7 @@ httproute:
             value: /
       backendRefs:
         - name: homarr
-          port: 8080
+          port: 7575
 ````
 </details>
 

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -234,7 +234,7 @@ httproute:
       filters: []
       backendRefs:
         - name: homarr
-          port: 8080
+          port: 7575
 
 # Ingress configuration
 ingress:


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)
- [x] Follow detailed instructions on how to get started with our project, see [about contributing to Chart](https://github.com/homarr-labs/charts/blob/dev/.github/CONTRIBUTING.md)

---
Currently the HTTPRoute created with `httproute.enabled=true` has a backendRefs that targets the default homarr service on port 8080, however the service has its port defined on 7575, generating 500 type errors when accesing Homarr, this commit changes the default port to 7575 in the backendRefs, thus requiring less values to be defined in order to get the chart working out of the box.

CLOSES: #269 